### PR TITLE
fix bug when getting dives

### DIFF
--- a/src/index.py
+++ b/src/index.py
@@ -50,6 +50,15 @@ class Dives(Resource):
     def get(self):
         dives = Dive.objects.values()
         data = [util.parse_mongo_to_jsonable(dive) for dive in dives]
+        for dive in data:
+            diver = User.objects.raw({
+                '_id': {'$eq': dive['diver']}
+            }).first()
+            target = Target.objects.raw({
+                '_id': {'$eq': dive['target']}
+            }).first()
+            dive['diver'] = diver.to_json()
+            dive['target'] = target.to_json()
         return {'data': data}
 
     def post(self):

--- a/src/models/target.py
+++ b/src/models/target.py
@@ -53,7 +53,7 @@ class Target(MongoModel):
 
     def to_json(self):
         return {
-            'id': self.target_id,
+            'id': str(self.target_id),
             'name': self.name,
             'town': self.town,
             'type': self.type,


### PR DESCRIPTION
`/api/dives` endpointin GET ei toiminut, koska viittauksien `id` kentät jäi `ObjectId` muotoon, korjattu ja muokattu palauttamaan viittauksien kaikki tiedot.