### PR TITLE
New targets to list

### DIFF
--- a/src/index.py
+++ b/src/index.py
@@ -169,9 +169,11 @@ class Users(Resource):
 @api.route('/api/targets')
 class Targets(Resource):
     def get(self):
-        targets = Target.objects.values()
-        data = [util.parse_mongo_to_jsonable(target) for target in targets]
-        return {'data': data}
+        targets = Target.objects.all()
+        data = []
+        for target in targets:
+            data.append(target.to_json())
+        return {'features': data}
 
     def post(self):
         data = util.parse_byte_string_to_dict(request.data)

--- a/src/index.py
+++ b/src/index.py
@@ -171,9 +171,11 @@ class Users(Resource):
 @api.route('/api/targets')
 class Targets(Resource):
     def get(self):
-        targets = Target.objects.values()
-        data = [util.parse_mongo_to_jsonable(target) for target in targets]
-        return {'data': data}
+        targets = Target.objects.all()
+        data = []
+        for target in targets:
+            data.append(target.to_json())
+        return {'features': data}
 
     def post(self):
         data = util.parse_byte_string_to_dict(request.data)

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -31,7 +31,7 @@ class TestApiEndpoints(unittest.TestCase):
 
     def test_target_endpoint_get_returs_targets(self):
         response = requests.get(f'{BASE_URL}/targets').json()
-        self.assertGreater(len(response['data']), 1)
+        self.assertGreater(len(response['features']), 1)
 
     def test_user_endpoint_get_returns_users(self):
         user = User.create(
@@ -42,7 +42,7 @@ class TestApiEndpoints(unittest.TestCase):
         response = requests.get(f'{BASE_URL}/users').json()
         self.assertEqual(len(response['data']), 1)
         self.assertEqual(response['data'][0]['name'], user.name)
-    
+
     def test_new_coordinates_targets(self):
         response = requests.get(f'{BASE_URL}/targets/newcoordinates')
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Tää muutos hakee hylkylistan sisällön tietokannasta samanmuotoisena kuin targetdata.json -tiedosto on. 
Tää tarvitaan frontin PR:n toimimiseksi jossa myös uudet hylyt on mukana hylkylistassa.

Luonnoksena niin kauan kunnes J-P:n frontin bugi on korjattu että voi testata tänkin kunnolla.