### PR TITLE
target notification fixes and new model

### DIFF
--- a/src/models/targetnote.py
+++ b/src/models/targetnote.py
@@ -1,0 +1,36 @@
+from pymodm import MongoModel, fields
+from models.target import Target
+from models.user import User
+
+
+class Targetnote(MongoModel):
+    diver = fields.ReferenceField(User, required=True)
+    target = fields.ReferenceField(Target, required=True)
+    created_at = fields.DateTimeField()
+    miscellaneous = fields.CharField(blank=True)
+
+    class Meta:
+        connection_alias = 'app'
+        final = True
+
+    @staticmethod
+    def create(
+        diver,
+        target,
+        miscellaneous=None
+    ):
+        targetnote = Targetnote(
+            diver,
+            target,
+            target.created_at,
+            miscellaneous
+        )
+        targetnote.save()
+        return targetnote
+
+    def to_json(self):
+        return {
+            'diver': self.diver.to_json(),
+            'target': self.target.to_json(),
+            'miscellaneous': self.miscellaneous
+        }

--- a/src/tests/test_targetnote.py
+++ b/src/tests/test_targetnote.py
@@ -1,0 +1,54 @@
+import unittest
+import datetime
+from pymodm import errors
+from models.targetnote import Targetnote
+from models.target import Target
+from models.user import User
+
+
+class TestTargetnote(unittest.TestCase):
+    def setUp(self):
+        users = Targetnote.objects.all()
+        for user in users:
+            user.delete()
+
+    def test_targetnote_cannot_be_created_without_diver(self):
+        target = Target.create(target_id = '999999999999',
+                            name = 'Testihylky',
+                            town = 'SaimaaTesti',
+                            type = 'Hylky',
+                            x_coordinate = 25.0,
+                            y_coordinate = 61.0,
+                            location_method = 'gpstesti',
+                            location_accuracy = 'huonotesti',
+                            url = 'https://testiurl.com',
+                            created_at = datetime.datetime.now(),
+                            is_ancient = False,
+                            source = 'ilmoitus')
+        targetnote = Targetnote(target=target)
+        with self.assertRaises(errors.ValidationError):
+            targetnote.save()
+
+    def test_targetnote_cannot_be_created_without_target(self):
+        user = User.create(name='test user', email='test@example.com', phone='2123213223')
+        targetnote = Targetnote(diver=user)
+        with self.assertRaises(errors.ValidationError):
+            targetnote.save()
+
+    def test_targetnote_can_be_created_with_target_and_diver(self):
+        target = Target.create(target_id = '9999999999991',
+                            name = 'Testihylky',
+                            town = 'SaimaaTesti',
+                            type = 'Hylky',
+                            x_coordinate = 25.0,
+                            y_coordinate = 61.0,
+                            location_method = 'gpstesti',
+                            location_accuracy = 'huonotesti',
+                            url = 'https://testiurl.com',
+                            created_at = datetime.datetime.now(),
+                            is_ancient = False,
+                            source = 'ilmoitus')
+        user = User.create(name='test user', email='test@example.com', phone='1234567')
+        targetnote = Targetnote(diver=user, target=target)
+        targetnote.save()
+        self.assertIsNotNone(targetnote._id)


### PR DESCRIPTION
Back-puolen toteutus sille että hylkyä ilmoittaessa ilmoittajan tiedot sekä annettu lisätietokenttä tallentuu tietokantaan.
Tätä varten uusi model targetnote joka sisältää viitteet sukeltajaan ja hylkyyn sekä sisältää lisätietokentän.

Hylkyä lisätessä tapahtuu nyt sama kuin sukellusilmoitusta lisätessä, eli ensin haetaan tietokannasta puh tai emailia vastaava käyttäjä (tai luodaan uusi) ja liitetään se ilmoitukseen hylyn kanssa.

Emailer hakee nyt hylkytiedot targetnoten kautta.

Vaatii fronin PR:n hyväksymistä: https://github.com/Sukellusilmoitus/frontend/pull/42