### PR TITLE
Target can be updated and can wait for approval

### DIFF
--- a/src/index.py
+++ b/src/index.py
@@ -182,7 +182,6 @@ class Targets(Resource):
 
     def post(self):
         data = util.parse_byte_string_to_dict(request.data)
-        print(data)
         target_id = data['id']
         divername = data['divername'],
         diver_email = data['email']

--- a/src/index.py
+++ b/src/index.py
@@ -170,11 +170,25 @@ class Users(Resource):
         created_user = User.create(name, email, phone)
         return {'data': {'user': created_user.to_json()}}, 201
 
+@api.route('/api/targets/pending')
+class TargetnotesPending(Resource):
+    def get(self):
+        data = []
+        targetnotes_all = Targetnote.objects.all()
+
+        for targetnote in targetnotes_all:
+            if targetnote.target.is_pending:
+                data.append(targetnote.to_json())
+
+        return {'features': data}
+
 
 @api.route('/api/targets')
 class Targets(Resource):
     def get(self):
-        targets = Target.objects.all()
+        targets = Target.objects.raw({
+                'is_pending': {'$ne': True}
+            }).all()
         data = []
         for target in targets:
             data.append(target.to_json())
@@ -183,37 +197,37 @@ class Targets(Resource):
     def post(self):
         data = util.parse_byte_string_to_dict(request.data)
         target_id = data['id']
-        divername = data['divername'],
+        divername = data['divername']
         diver_email = data['email']
         diver_phone = data['phone']
-        name = data['targetname'],
-        town = data['town'],
-        type = data['type'],
-        x_coordinate = data['x_coordinate'],
-        y_coordinate = data['y_coordinate'],
-        location_method = data['location_method'],
-        location_accuracy = data['location_accuracy'],
-        url = data['url'],
-        created_at = data['created_at'],
-        is_ancient = data['is_ancient'],
-        is_pending = data['is_pending'],
+        name = data['targetname']
+        town = data['town']
+        type = data['type']
+        x_coordinate = data['x_coordinate']
+        y_coordinate = data['y_coordinate']
+        location_method = data['location_method']
+        location_accuracy = data['location_accuracy']
+        url = data['url']
+        created_at = data['created_at']
+        is_ancient = data['is_ancient']
+        is_pending = data['is_pending']
         source = data['source']
         misc_text = data['miscText']
 
         created_target = Target.create(
             target_id,
-            name[0],
-            town[0],
-            type[0],
-            x_coordinate[0],
-            y_coordinate[0],
-            location_method[0],
-            location_accuracy[0],
-            url[0],
-            created_at[0],
-            is_ancient[0],
+            name,
+            town,
+            type,
+            x_coordinate,
+            y_coordinate,
+            location_method,
+            location_accuracy,
+            url,
+            created_at,
+            is_ancient,
             source,
-            is_pending[0],
+            is_pending,
         )
 
         try:
@@ -235,33 +249,33 @@ class TargetsUpdate(Resource):
     def post(self):
         data = util.parse_byte_string_to_dict(request.data)
         target_id = data['id']
-        name = data['targetname'],
-        town = data['town'],
-        type = data['type'],
-        x_coordinate = data['x_coordinate'],
-        y_coordinate = data['y_coordinate'],
-        location_method = data['location_method'],
-        location_accuracy = data['location_accuracy'],
+        name = data['targetname']
+        town = data['town']
+        type = data['type']
+        x_coordinate = data['x_coordinate']
+        y_coordinate = data['y_coordinate']
+        location_method = data['location_method']
+        location_accuracy = data['location_accuracy']
         url = data['url'],
-        created_at = data['created_at'],
-        is_ancient = data['is_ancient'],
-        is_pending = data['is_pending'],
+        created_at = data['created_at']
+        is_ancient = data['is_ancient']
+        is_pending = data['is_pending']
         source = data['source']
 
         updated_target = Target.update(
             target_id,
-            name[0],
-            town[0],
-            type[0],
-            x_coordinate[0],
-            y_coordinate[0],
-            location_method[0],
-            location_accuracy[0],
-            url[0],
-            created_at[0],
-            is_ancient[0],
+            name,
+            town,
+            type,
+            x_coordinate,
+            y_coordinate,
+            location_method,
+            location_accuracy,
+            url,
+            created_at,
+            is_ancient,
             source,
-            is_pending[0],
+            is_pending,
         )
 
         return {'data': {'target': updated_target.to_json()}}, 201

--- a/src/index.py
+++ b/src/index.py
@@ -197,6 +197,7 @@ class Targets(Resource):
         url = data['url'],
         created_at = data['created_at'],
         is_ancient = data['is_ancient'],
+        is_pending = data['is_pending'],
         source = data['source']
         misc_text = data['miscText']
 
@@ -212,7 +213,8 @@ class Targets(Resource):
             url[0],
             created_at[0],
             is_ancient[0],
-            source
+            source,
+            is_pending[0],
         )
 
         try:

--- a/src/index.py
+++ b/src/index.py
@@ -175,13 +175,11 @@ class TargetnotesPending(Resource):
     def get(self):
         data = []
         targetnotes_all = Targetnote.objects.all()
-
         for targetnote in targetnotes_all:
             if targetnote.target.is_pending:
                 data.append(targetnote.to_json())
 
         return {'features': data}
-
 
 @api.route('/api/targets')
 class Targets(Resource):
@@ -285,7 +283,6 @@ class TargetsAccept(Resource):
     def post(self):
         data = util.parse_byte_string_to_dict(request.data)
         target_id = data['id']
-
         accepted_target = Target.accept(target_id)
 
         return {'data': {'target': accepted_target.to_json()}}, 201

--- a/src/index.py
+++ b/src/index.py
@@ -230,6 +230,52 @@ class Targets(Resource):
         return {'data': {'target': created_target.to_json(),
                          'targetnote': created_targetnote.to_json()}}, 201
 
+@api.route('/api/targets/update')
+class TargetsUpdate(Resource):
+    def post(self):
+        data = util.parse_byte_string_to_dict(request.data)
+        target_id = data['id']
+        name = data['targetname'],
+        town = data['town'],
+        type = data['type'],
+        x_coordinate = data['x_coordinate'],
+        y_coordinate = data['y_coordinate'],
+        location_method = data['location_method'],
+        location_accuracy = data['location_accuracy'],
+        url = data['url'],
+        created_at = data['created_at'],
+        is_ancient = data['is_ancient'],
+        is_pending = data['is_pending'],
+        source = data['source']
+
+        updated_target = Target.update(
+            target_id,
+            name[0],
+            town[0],
+            type[0],
+            x_coordinate[0],
+            y_coordinate[0],
+            location_method[0],
+            location_accuracy[0],
+            url[0],
+            created_at[0],
+            is_ancient[0],
+            source,
+            is_pending[0],
+        )
+
+        return {'data': {'target': updated_target.to_json()}}, 201
+
+@api.route('/api/targets/accept')
+class TargetsAccept(Resource):
+    def post(self):
+        data = util.parse_byte_string_to_dict(request.data)
+        target_id = data['id']
+
+        accepted_target = Target.accept(target_id)
+
+        return {'data': {'target': accepted_target.to_json()}}, 201
+
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/src/models/target.py
+++ b/src/models/target.py
@@ -1,5 +1,5 @@
+# pylint: disable-msg=too-many-arguments
 from pymodm import MongoModel, fields
-
 
 class Target(MongoModel):
     target_id = fields.CharField(primary_key=True)
@@ -93,14 +93,16 @@ class Target(MongoModel):
 
     @staticmethod
     def accept(target_id):
-        target = Target.objects.raw({
-            '_id': {'$eq': target_id}
-        }).first()
-        if target.is_pending:
-            target.is_pending = False
-            target.save()
-        return target
-
+        try:
+            target = Target.objects.raw({
+                '_id': {'$eq': target_id}
+            }).first()
+            if target.is_pending:
+                target.is_pending = False
+                target.save()
+            return target
+        except Target.DoesNotExist:
+            return None
 
     def to_json(self):
         return {

--- a/src/models/target.py
+++ b/src/models/target.py
@@ -14,6 +14,7 @@ class Target(MongoModel):
     created_at = fields.DateTimeField()
     is_ancient = fields.BooleanField(blank=True)
     source = fields.CharField()
+    is_pending = fields.BooleanField(blank=True)
 
     class Meta:
         connection_alias = 'app'
@@ -32,7 +33,8 @@ class Target(MongoModel):
         url,
         created_at,
         is_ancient,
-        source
+        source,
+        is_pending
     ):
         target = Target(
             target_id=target_id,
@@ -46,7 +48,8 @@ class Target(MongoModel):
             url=url,
             created_at=created_at,
             is_ancient=is_ancient,
-            source=source
+            source=source,
+            is_pending=is_pending
         )
         target.save()
         return target

--- a/src/models/target.py
+++ b/src/models/target.py
@@ -3,17 +3,17 @@ from pymodm import MongoModel, fields
 
 class Target(MongoModel):
     target_id = fields.CharField(primary_key=True)
-    name = fields.CharField()
-    town = fields.CharField()
-    type = fields.CharField()
-    x_coordinate = fields.FloatField()
-    y_coordinate = fields.FloatField()
+    name = fields.CharField(required=True)
+    town = fields.CharField(required=True)
+    type = fields.CharField(required=True)
+    x_coordinate = fields.FloatField(required=True)
+    y_coordinate = fields.FloatField(required=True)
     location_method = fields.CharField(blank=True)
     location_accuracy = fields.CharField(blank=True)
-    url = fields.URLField()
-    created_at = fields.DateTimeField()
+    url = fields.URLField(blank=True)
+    created_at = fields.DateTimeField(blank=True)
     is_ancient = fields.BooleanField(blank=True)
-    source = fields.CharField()
+    source = fields.CharField(required=True)
     is_pending = fields.BooleanField(blank=True)
 
     class Meta:

--- a/src/models/target.py
+++ b/src/models/target.py
@@ -54,6 +54,54 @@ class Target(MongoModel):
         target.save()
         return target
 
+    @staticmethod
+    def update(
+        target_id,
+        name,
+        town,
+        type,
+        x_coordinate,
+        y_coordinate,
+        location_method,
+        location_accuracy,
+        url,
+        created_at,
+        is_ancient,
+        source,
+        is_pending
+    ):
+
+        target = Target.objects.raw({
+            '_id': {'$eq': target_id}
+        }).first()
+
+        target.name = name
+        target.town = town
+        target.type = type
+        target.x_coordinate = x_coordinate
+        target.y_coordinate = y_coordinate
+        target.location_method = location_method
+        target.location_accuracy = location_accuracy
+        target.url = url
+        target.created_at = created_at
+        target.is_ancient = is_ancient
+        target.source = source
+        target.is_pending = is_pending
+
+        target.save()
+        return target
+
+    @staticmethod
+    def accept(target_id):
+        target = Target.objects.raw({
+            '_id': {'$eq': target_id}
+        }).first()
+        if target.is_pending:
+            target.is_pending = False
+            target.save()
+        return target
+
+
     def to_json(self):
         return {
             'type': 'Feature',
@@ -67,7 +115,8 @@ class Target(MongoModel):
                 'url': self.url,
                 'created_at': str(self.created_at).split(' ')[0],
                 'is_ancient': self.is_ancient,
-                'source': self.source
+                'source': self.source,
+                'is_pending': self.is_pending
             },
             'geometry': {
                 'type': 'Point',

--- a/src/save_to_db.py
+++ b/src/save_to_db.py
@@ -22,6 +22,7 @@ for feature in features:
     is_ancient = properties['is_ancient']
     source = properties['source'] or 'unknown'
     x_coordinate, y_coordinate = feature['geometry']['coordinates']
+    is_pending = properties['is_pending']
 
     Target.create(
         target_id,
@@ -35,5 +36,6 @@ for feature in features:
         url,
         created_at,
         is_ancient,
-        source
+        source,
+        is_pending
     )

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -51,19 +51,19 @@ class TestApiEndpoints(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_data_endpoint_returns_pending_targets(self):
-        target = Target.create(target_id = '9999999999991',
-                            name = 'Testihylky',
-                            town = 'SaimaaTesti',
-                            type = 'Hylky',
-                            x_coordinate = 25.0,
-                            y_coordinate = 61.0,
-                            location_method = 'gpstesti',
-                            location_accuracy = 'huonotesti',
-                            url = 'https://testiurl.com',
-                            created_at = datetime.datetime.now(),
-                            is_ancient = False,
-                            source = 'ilmoitus',
-                            is_pending = True)
+        target = Target.create(target_id='9999999999991',
+                               name='Testihylky',
+                               town='SaimaaTesti',
+                               type='Hylky',
+                               x_coordinate=25.0,
+                               y_coordinate=61.0,
+                               location_method='gpstesti',
+                               location_accuracy='huonotesti',
+                               url='https://testiurl.com',
+                               created_at=datetime.datetime.now(),
+                               is_ancient=False,
+                               source='ilmoitus',
+                               is_pending=True)
         user = User.create(name='test user', email='test@example.com', phone='1234567')
         targetnote = Targetnote(diver=user, target=target)
         targetnote.save()

--- a/src/tests/test_target.py
+++ b/src/tests/test_target.py
@@ -1,0 +1,79 @@
+import unittest
+import datetime
+from models.target import Target
+
+
+class TestTarget(unittest.TestCase):
+    def setUp(self):
+        targets = Target.objects.raw({
+            'source': {'$eq': 'ilmoitus'}
+        }).all()
+        for target in targets:
+            target.delete()
+
+    def test_target_can_be_created_with_right_parameters(self):
+        Target.create(target_id='9999999999991',
+                      name='Testihylky',
+                      town='SaimaaTesti',
+                      type='Hylky',
+                      x_coordinate=25.0,
+                      y_coordinate=61.0,
+                      location_method='gpstesti',
+                      location_accuracy='huonotesti',
+                      url='https://testiurl.com',
+                      created_at=datetime.datetime.now(),
+                      is_ancient=False,
+                      source='ilmoitus',
+                      is_pending=True)
+        self.assertGreater(Target.objects.raw({
+            'source': {'$eq': 'ilmoitus'}
+        }).all().count(), 0)
+
+    def test_target_is_not_pending_after_accepting(self):
+        target = Target(target_id='9999999999992',
+                        name='Testihylky2',
+                        town='SaimaaTesti',
+                        type='Hylky',
+                        x_coordinate=25.0,
+                        y_coordinate=61.0,
+                        location_method='gpstesti',
+                        location_accuracy='huonotesti',
+                        url='https://testiurl.com',
+                        created_at=datetime.datetime.now(),
+                        is_ancient=False,
+                        source='ilmoitus',
+                        is_pending=True)
+        target.save()
+        accepted_target = Target.accept('9999999999992')
+        self.assertFalse(accepted_target.is_pending)
+
+    def test_target_can_be_updated(self):
+        target = Target(target_id='9999999999993',
+                        name='Testihylky3',
+                        town='SaimaaTesti',
+                        type='Hylky',
+                        x_coordinate=25.0,
+                        y_coordinate=61.0,
+                        location_method='gpstesti',
+                        location_accuracy='huonotesti',
+                        url='https://testiurl.com',
+                        created_at=datetime.datetime.now(),
+                        is_ancient=False,
+                        source='ilmoitus',
+                        is_pending=True)
+        target.save()
+        updated_target = Target.update(target_id='9999999999993',
+                                       name='Testihylky3',
+                                       town='SaimaaTesti',
+                                       type='Hylky',
+                                       x_coordinate=26.666666,
+                                       y_coordinate=61.0,
+                                       location_method='gpstesti',
+                                       location_accuracy='huonotesti',
+                                       url='https://oikeatestiurl.com',
+                                       created_at=datetime.datetime.now(),
+                                       is_ancient=False,
+                                       source='ilmoitus',
+                                       is_pending=True)
+        self.assertEqual(updated_target.x_coordinate, 26.666666)
+        self.assertEqual(updated_target.url, 'https://oikeatestiurl.com')

--- a/src/tests/test_target.py
+++ b/src/tests/test_target.py
@@ -1,7 +1,7 @@
 import unittest
 import datetime
+from pymodm import errors
 from models.target import Target
-
 
 class TestTarget(unittest.TestCase):
     def setUp(self):
@@ -10,6 +10,37 @@ class TestTarget(unittest.TestCase):
         }).all()
         for target in targets:
             target.delete()
+
+    def test_target_cannot_be_created_without_name(self):
+        target = Target(target_id='99999999999',
+                        town='SaimaaTesti',
+                        type='Hylky',
+                        x_coordinate=25.0,
+                        y_coordinate=61.0,
+                        location_method='gpstesti',
+                        location_accuracy='huonotesti',
+                        url='https://testiurl.com',
+                        created_at=datetime.datetime.now(),
+                        is_ancient=False,
+                        source='ilmoitus',
+                        is_pending=True)
+        with self.assertRaises(errors.ValidationError):
+            target.save()
+
+    def test_target_cannot_be_created_without_coordinates(self):
+        target = Target(target_id='99999999999',
+                        name='Testihylky',
+                        town='SaimaaTesti',
+                        type='Hylky',
+                        location_method='gpstesti',
+                        location_accuracy='huonotesti',
+                        url='https://testiurl.com',
+                        created_at=datetime.datetime.now(),
+                        is_ancient=False,
+                        source='ilmoitus',
+                        is_pending=True)
+        with self.assertRaises(errors.ValidationError):
+            target.save()
 
     def test_target_can_be_created_with_right_parameters(self):
         Target.create(target_id='9999999999991',
@@ -77,3 +108,25 @@ class TestTarget(unittest.TestCase):
                                        is_pending=True)
         self.assertEqual(updated_target.x_coordinate, 26.666666)
         self.assertEqual(updated_target.url, 'https://oikeatestiurl.com')
+
+    def test_target_json_format_is_geojson(self):
+        target = Target(target_id='9999999999991',
+                        name='Testihylky',
+                        town='SaimaaTesti',
+                        type='Hylky',
+                        x_coordinate=25.0,
+                        y_coordinate=61.0,
+                        location_method='gpstesti',
+                        location_accuracy='huonotesti',
+                        url='https://testiurl.com',
+                        created_at=datetime.datetime.now(),
+                        is_ancient=False,
+                        source='ilmoitus',
+                        is_pending=True)
+
+        self.assertEqual(len(target.to_json()), 3)
+        self.assertEqual(target.to_json()['type'], 'Feature')
+        self.assertEqual(len(target.to_json()['properties']), 11)
+        self.assertEqual(len(target.to_json()['geometry']), 2)
+        self.assertEqual(len(target.to_json()['geometry']['coordinates']), 2)
+        self.assertEqual(target.to_json()['geometry']['type'], 'Point')

--- a/src/tests/test_targetnote.py
+++ b/src/tests/test_targetnote.py
@@ -24,7 +24,8 @@ class TestTargetnote(unittest.TestCase):
                             url = 'https://testiurl.com',
                             created_at = datetime.datetime.now(),
                             is_ancient = False,
-                            source = 'ilmoitus')
+                            source = 'ilmoitus',
+                            is_pending = True)
         targetnote = Targetnote(target=target)
         with self.assertRaises(errors.ValidationError):
             targetnote.save()
@@ -47,7 +48,8 @@ class TestTargetnote(unittest.TestCase):
                             url = 'https://testiurl.com',
                             created_at = datetime.datetime.now(),
                             is_ancient = False,
-                            source = 'ilmoitus')
+                            source = 'ilmoitus',
+                            is_pending = True)
         user = User.create(name='test user', email='test@example.com', phone='1234567')
         targetnote = Targetnote(diver=user, target=target)
         targetnote.save()

--- a/src/tests/test_targetnote.py
+++ b/src/tests/test_targetnote.py
@@ -8,9 +8,9 @@ from models.user import User
 
 class TestTargetnote(unittest.TestCase):
     def setUp(self):
-        users = Targetnote.objects.all()
-        for user in users:
-            user.delete()
+        targetnotes = Targetnote.objects.all()
+        for targetnote in targetnotes:
+            targetnote.delete()
 
     def test_targetnote_cannot_be_created_without_diver(self):
         target = Target.create(target_id = '999999999999',

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -26,7 +26,8 @@ class TestUtils(unittest.TestCase):
             'url',
             'created_at',
             True,
-            'source'
+            'source',
+            True
         )
         parsed = util.parse_mongo_to_jsonable(target.to_json())
         assert parsed == {
@@ -41,7 +42,8 @@ class TestUtils(unittest.TestCase):
                 'url': 'url',
                 'created_at': 'created_at',
                 'is_ancient': True,
-                'source': 'source'
+                'source': 'source',
+                'is_pending': True
             },
             'geometry': {
                 'type': 'Point',


### PR DESCRIPTION
Target-modelilla uusi muuttuja `is_pending`, joka on alussa aina `True`. Hylyn voi hyväksyä modelilla `Target.accept(hylyn_id)`.
Kartalla ja listassa näkyvät nyt vain hylyt jotka eivät ole pending.
API toteutus hylyn hyväksymiselle toimii POST-metodilla `/api/targets/accept`

Kaikki hyväksyntää odottavat hylkyilmoitukset (hylkyineen) saa GET:illä `/api/targets/pending`

Target-modelilla on nyt myös create-toiminnon kaltainen update-toiminto `Target.update(hylyn_id, uusinimi, ...)` . Hylkyä voi päivittää POST-metodilla jossa on kaikki hylyn muutettavat ja ennalleen jäävät tiedot mukana
`/api/targets/update`

lisäksi alustavat yksikkötestit

Liittyy frontin PR:ään https://github.com/Sukellusilmoitus/frontend/pull/52