### PR TITLE
Delete cascade

### DIFF
--- a/src/models/dive.py
+++ b/src/models/dive.py
@@ -6,7 +6,7 @@ from models.user import User
 
 class Dive(MongoModel):
     diver = fields.ReferenceField(User)
-    target = fields.ReferenceField(Target)
+    target = fields.ReferenceField(Target, on_delete=fields.ReferenceField.CASCADE)
     created_at = fields.DateTimeField()
     divedate = fields.CharField(blank=True)
     location_correct = fields.BooleanField()

--- a/src/models/targetnote.py
+++ b/src/models/targetnote.py
@@ -5,7 +5,7 @@ from models.user import User
 
 class Targetnote(MongoModel):
     diver = fields.ReferenceField(User, required=True)
-    target = fields.ReferenceField(Target, required=True)
+    target = fields.ReferenceField(Target, required=True, on_delete=fields.ReferenceField.CASCADE)
     created_at = fields.DateTimeField()
     miscellaneous = fields.CharField(blank=True)
 

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -355,7 +355,8 @@ class TestApiEndpoints(unittest.TestCase):
                     new_y_coordinate=None,
                     new_location_explanation=None,
                     change_text='testimuutoksia',
-                    miscellaneous=None)
+                    miscellaneous=None,
+                    divedate=datetime.datetime.now())
         Dive.create(diver=user1,
                     target=target2,
                     location_correct=True,
@@ -364,7 +365,8 @@ class TestApiEndpoints(unittest.TestCase):
                     new_y_coordinate=None,
                     new_location_explanation=None,
                     change_text='testimuutoksia2',
-                    miscellaneous='terveisiä')
+                    miscellaneous='terveisiä',
+                    divedate=datetime.datetime.now())
         Dive.create(diver=user2,
                     target=target1,
                     location_correct=True,
@@ -373,7 +375,8 @@ class TestApiEndpoints(unittest.TestCase):
                     new_y_coordinate=None,
                     new_location_explanation=None,
                     change_text='väärä user',
-                    miscellaneous='moi')
+                    miscellaneous='moi',
+                    divedate=datetime.datetime.now())
         response = requests.get(f'{BASE_URL}/dives/user/test1').json()
         data = response['data']
         first_feature = data[0]
@@ -428,7 +431,8 @@ class TestApiEndpoints(unittest.TestCase):
                     new_y_coordinate=None,
                     new_location_explanation=None,
                     change_text='väärä user',
-                    miscellaneous='moi')
+                    miscellaneous='moi',
+                    divedate=datetime.datetime.now())
         response = requests.get(f'{BASE_URL}/dives/user/test1').json()
         data = response['data']
         self.assertEqual(len(data), 0)

--- a/src/tests/test_dive.py
+++ b/src/tests/test_dive.py
@@ -1,0 +1,93 @@
+import unittest
+import datetime
+from pymodm import errors
+from models.dive import Dive
+from models.target import Target
+from models.user import User
+
+class TestDive(unittest.TestCase):
+    def setUp(self):
+        dives = Dive.objects.all()
+        for dive in dives:
+            dive.delete()
+
+    def test_target_is_not_deleted_when_dive_is_deleted(self):
+        target1 = Target.create(target_id='99999999999910',
+                               name='Testihylky0',
+                               town='SaimaaTesti',
+                               type='Hylky',
+                               x_coordinate=25.0,
+                               y_coordinate=61.0,
+                               location_method='gpstesti',
+                               location_accuracy='huonotesti',
+                               url='https://testiurl.com',
+                               created_at=datetime.datetime.now(),
+                               is_ancient=False,
+                               source='ilmoitus',
+                               is_pending=True)
+
+        user1 = User.create(name='test user11',
+                           email='test1@example.com',
+                           phone='1234567',
+                           password='test',
+                           username='test11'
+                           )
+
+        dive = Dive.create(diver=user1,
+                           target=target1,
+                           location_correct=True,
+                           created_at=datetime.datetime.now(),
+                           new_x_coordinate=None,
+                           new_y_coordinate=None,
+                           new_location_explanation=None,
+                           change_text='testimuutoksia',
+                           miscellaneous=None,
+                           divedate=datetime.datetime.now())
+
+        dive_id = dive._id
+        self.assertIsNotNone(Dive.objects.raw({'_id': dive_id}).first())
+        dive.delete()
+        with self.assertRaises(Exception):
+            Dive.objects.raw({'_id': dive_id}).first()
+        self.assertIsNotNone(Target.objects.raw({'_id': '99999999999910'}).first())
+
+    def test_dive_is_deleted_when_target_is_deleted(self):
+        target1 = Target.create(target_id='99999999999911',
+                               name='Testihylky01',
+                               town='SaimaaTesti',
+                               type='Hylky',
+                               x_coordinate=25.0,
+                               y_coordinate=61.0,
+                               location_method='gpstesti',
+                               location_accuracy='huonotesti',
+                               url='https://testiurl.com',
+                               created_at=datetime.datetime.now(),
+                               is_ancient=False,
+                               source='ilmoitus',
+                               is_pending=True)
+
+        user1 = User.create(name='test user11',
+                           email='test1@example.com',
+                           phone='1234567',
+                           password='test',
+                           username='test11'
+                           )
+
+        dive = Dive.create(diver=user1,
+                           target=target1,
+                           location_correct=True,
+                           created_at=datetime.datetime.now(),
+                           new_x_coordinate=None,
+                           new_y_coordinate=None,
+                           new_location_explanation=None,
+                           change_text='testimuutoksia',
+                           miscellaneous=None,
+                           divedate=datetime.datetime.now())
+
+        dive_id = dive._id
+        self.assertIsNotNone(Dive.objects.raw({'_id': dive_id}).first())
+        target1.delete()
+        with self.assertRaises(errors.DoesNotExist):
+            Dive.objects.raw({'_id': dive_id}).first()
+        with self.assertRaises(errors.DoesNotExist):
+            Target.objects.raw({'_id': '99999999999911'}).first()

--- a/src/tests/test_targetnote.py
+++ b/src/tests/test_targetnote.py
@@ -58,3 +58,58 @@ class TestTargetnote(unittest.TestCase):
         targetnote = Targetnote(diver=user, target=target)
         targetnote.save()
         self.assertIsNotNone(targetnote._id)
+
+    def test_targetnote_is_deleted_when_target_is_deleted(self):
+        target = Target.create(target_id='999999999999222',
+                               name='Testihylky22',
+                               town='SaimaaTesti',
+                               type='Hylky',
+                               x_coordinate=25.0,
+                               y_coordinate=61.0,
+                               location_method='gpstesti',
+                               location_accuracy='huonotesti',
+                               url='https://testiurl.com',
+                               created_at=datetime.datetime.now(),
+                               is_ancient=False,
+                               source='ilmoitus',
+                               is_pending=True)
+        user = User.create(name='test user 2',
+                           email='test@example.com',
+                           phone='1234567',
+                           username='username2',
+                           password='password')
+        targetnote = Targetnote.create(diver=user, target=target, miscellaneous='testnote')
+        tn_id = targetnote._id
+        self.assertIsNotNone(Targetnote.objects.raw({'_id': tn_id}).first())
+        target.delete()
+        with self.assertRaises(errors.DoesNotExist):
+            Targetnote.objects.raw({'_id': tn_id}).first()
+        with self.assertRaises(errors.DoesNotExist):
+            Target.objects.raw({'_id': '999999999999222'}).first()
+
+    def test_target_is_not_deleted_when_targetnote_is_deleted(self):
+        target = Target.create(target_id='9999999999992223',
+                               name='Testihylky223',
+                               town='SaimaaTesti',
+                               type='Hylky',
+                               x_coordinate=25.0,
+                               y_coordinate=61.0,
+                               location_method='gpstesti',
+                               location_accuracy='huonotesti',
+                               url='https://testiurl.com',
+                               created_at=datetime.datetime.now(),
+                               is_ancient=False,
+                               source='ilmoitus',
+                               is_pending=True)
+        user = User.create(name='test user 3',
+                           email='test@example.com',
+                           phone='1234567',
+                           username='username3',
+                           password='password')
+        targetnote = Targetnote.create(diver=user, target=target, miscellaneous='testnote')
+        tn_id = targetnote._id
+        self.assertIsNotNone(Targetnote.objects.raw({'_id': tn_id}).first())
+        targetnote.delete()
+        with self.assertRaises(errors.DoesNotExist):
+            Targetnote.objects.raw({'_id': tn_id}).first()
+        self.assertIsNotNone(Target.objects.raw({'_id': '9999999999992223'}).first())


### PR DESCRIPTION
Lisätty delete cascade sukellus- ja hylkyilmoituksiin, eli ne poistuvat jos niihin liittyvä hylky poistetaan. 
Käyttäjän osalta tätä ei ole totetutettu koska oli puhetta että käyttäjiä ei poisteta.

Vanhat pytestit korjattu ja uusia lisätty.
//edit: J-P olikin näköjään tehnyt saman korjauksen test_api.py:hyn aiemmassa PR:ssä, mergetessä jätän J-P:n muutokset voimaan