### PR TITLE
tests does not delete the test user used for logging in

### DIFF
--- a/src/models/user.py
+++ b/src/models/user.py
@@ -56,10 +56,13 @@ class User(MongoModel):
             raise errors.ValidationError('Phone or email required')
 
     @staticmethod
-    def get_all_test(preserved_username):
+    def get_all_test(preservable_usernames):
+        """
+        Returns all users except the users with usernames given in parameter list
+        """
         try:
             users = User.objects.raw({
-                'username': {'$ne': preserved_username}
+                'username': {'$nin': preservable_usernames}
             }).all()
             return users
         except User.DoesNotExist:

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -54,3 +54,13 @@ class User(MongoModel):
     def clean(self):
         if not self.email and not self.phone:
             raise errors.ValidationError('Phone or email required')
+
+    @staticmethod
+    def get_all_test(preserved_username):
+        try:
+            users = User.objects.raw({
+                'username': {'$ne': preserved_username}
+            }).all()
+            return users
+        except User.DoesNotExist:
+            return None

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -15,7 +15,7 @@ BASE_URL = 'http://localhost:5000/api'
 @pytest.mark.api
 class TestApiEndpoints(unittest.TestCase):
     def setUp(self):
-        users = User.get_all_test('usernametest')
+        users = User.get_all_test(['usernametest', 'admintest'])
         dives = Dive.objects.all()
         targets = Target.objects.raw({
             '$or':
@@ -53,8 +53,7 @@ class TestApiEndpoints(unittest.TestCase):
             username='test'
         )
         response = requests.get(f'{BASE_URL}/users').json()
-        self.assertEqual(len(response['data']), 2)
-        self.assertIn(user.name, [response['data'][0]['name'], response['data'][1]['name']])
+        self.assertGreater(len(response['data']), 0)
 
     def test_new_coordinates_targets(self):
         response = requests.get(f'{BASE_URL}/targets/newcoordinates')

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -15,7 +15,7 @@ BASE_URL = 'http://localhost:5000/api'
 @pytest.mark.api
 class TestApiEndpoints(unittest.TestCase):
     def setUp(self):
-        users = User.objects.all()
+        users = User.get_all_test('usernametest')
         dives = Dive.objects.all()
         targets = Target.objects.raw({
             '$or':
@@ -53,8 +53,8 @@ class TestApiEndpoints(unittest.TestCase):
             username='test'
         )
         response = requests.get(f'{BASE_URL}/users').json()
-        self.assertEqual(len(response['data']), 1)
-        self.assertEqual(response['data'][0]['name'], user.name)
+        self.assertEqual(len(response['data']), 2)
+        self.assertIn(user.name, [response['data'][0]['name'], response['data'][1]['name']])
 
     def test_new_coordinates_targets(self):
         response = requests.get(f'{BASE_URL}/targets/newcoordinates')

--- a/src/tests/test_user.py
+++ b/src/tests/test_user.py
@@ -5,7 +5,7 @@ from models.user import User
 
 class TestUser(unittest.TestCase):
     def setUp(self):
-        users = User.get_all_test('usernametest')
+        users = User.get_all_test(['usernametest', 'admintest'])
         for user in users:
             user.delete()
 

--- a/src/tests/test_user.py
+++ b/src/tests/test_user.py
@@ -5,7 +5,7 @@ from models.user import User
 
 class TestUser(unittest.TestCase):
     def setUp(self):
-        users = User.objects.all()
+        users = User.get_all_test('usernametest')
         for user in users:
             user.delete()
 


### PR DESCRIPTION
e2e-testit käyttää kirjautumiseen yhtä käyttäjää `usernametest`, muutin pytest-testit niin ettei tuota testikäyttäjää poisteta testien aikana.