### PR TITLE
update admin/dives route faster

### DIFF
--- a/src/index.py
+++ b/src/index.py
@@ -49,7 +49,7 @@ def token_required(wrapped):
                 return 'Unauthorized Access!', 401
         except (errors.DoesNotExist, errors.ModelDoesNotExist):
             return 'Unauthorized Access!', 401
-        except jwt.exceptions.InvalidSignatureError:
+        except (jwt.exceptions.InvalidSignatureError, jwt.exceptions.DecodeError):
             return 'Unauthorized Access!', 401
         return wrapped(*args, **kwargs)
     return decorated
@@ -483,34 +483,45 @@ class AdminPanelDives(Resource):
     @admin_required
     def get(self):
         """api route for adminpanel dives page
+        Compared to other admin queries, the data is first sorted using lambda.
+        And then only the desired amount is converted to admin json.
+        This makes the queary faster.
 
         Returns:
             code 200: return 200, dives data and X-Total-Count
         """
         start = int(request.args.get('_start') or 0)
         end = int(request.args.get('_end') or 10)
-        sortby = request.args.get('_sort', 'ASC')
-        order = request.args.get('_order', 'id')
+        sortby = request.args.get('_sort', 'id')
+        order = request.args.get('_order', 'ASC')
 
         dives = Dive.objects.all()
-        dives_json_list = []
-        for dive in dives:
-            try:
-                dives_json_list.append(dive.to_json_admin())
-            except AttributeError:
-                pass
-        try:
-            dives_json_list.sort(key=lambda user: user[sortby],
-                                 reverse=order == 'ASC')
-        except KeyError:
-            pass
+        dives_list = list(dives)
+        if sortby == 'id':
+            dives_list = sorted(dives_list, key=lambda d: d._id, reverse= order == 'ASC')
+        if sortby == 'diver_name':
+            dives_list = sorted(dives_list, key=lambda d: d.diver.name, reverse= order == 'ASC')
+        if sortby == 'target_name':
+            dives_list = sorted(dives_list, key=lambda d: d.target.name, reverse= order == 'ASC')
+        if sortby == 'created_at':
+            dives_list = sorted(dives_list, key=lambda d: d.created_at, reverse= order == 'ASC')
+        if sortby == 'location_correct':
+            dives_list = sorted(dives_list, key=lambda d: d.location_correct, reverse= order == 'ASC')
+        if sortby == 'new_x_coordinate':
+            dives_list = sorted(dives_list, key=lambda d: d.new_x_coordinate, reverse= order == 'ASC')
+        if sortby == 'new_y_coordinate':
+            dives_list = sorted(dives_list, key=lambda d: d.new_y_coordinate, reverse= order == 'ASC')
+        if sortby == 'change_text':
+            dives_list = sorted(dives_list, key=lambda d: d.change_text, reverse= order == 'ASC')
+        if sortby == 'miscellaneous':
+            dives_list = sorted(dives_list, key=lambda d: d.miscellaneous, reverse= order == 'ASC')
 
-        dives_count = len(dives_json_list)
+        dives_count = len(dives_list)
         data = []
         for i in range(start, end):
             try:
-                data.append(dives_json_list[i])
-            except IndexError:
+                data.append(dives_list[i].to_json_admin())
+            except (IndexError, AttributeError):
                 pass
         return data, 200, {
             'Access-Control-Expose-Headers': 'X-Total-Count',

--- a/src/index.py
+++ b/src/index.py
@@ -503,8 +503,8 @@ class AdminPanelDives(Resource):
             dives_list = sorted(dives_list, key=lambda d: d.diver.name, reverse= order == 'ASC')
         if sortby == 'target_name':
             dives_list = sorted(dives_list, key=lambda d: d.target.name, reverse= order == 'ASC')
-        if sortby == 'created_at':
-            dives_list = sorted(dives_list, key=lambda d: d.created_at, reverse= order == 'ASC')
+        if sortby == 'divedate':
+            dives_list = sorted(dives_list, key=lambda d: d.divedate, reverse= order == 'ASC')
         if sortby == 'location_correct':
             dives_list = sorted(dives_list, key=lambda d: d.location_correct, reverse= order == 'ASC')
         if sortby == 'new_x_coordinate':

--- a/src/index.py
+++ b/src/index.py
@@ -498,23 +498,32 @@ class AdminPanelDives(Resource):
         dives = Dive.objects.all()
         dives_list = list(dives)
         if sortby == 'id':
-            dives_list = sorted(dives_list, key=lambda d: d._id, reverse= order == 'ASC')
+            dives_list = sorted(dives_list, key=lambda d: d._id,
+            reverse= order == 'ASC')
         if sortby == 'diver_name':
-            dives_list = sorted(dives_list, key=lambda d: d.diver.name, reverse= order == 'ASC')
+            dives_list = sorted(dives_list, key=lambda d: d.diver.name,
+            reverse= order == 'ASC')
         if sortby == 'target_name':
-            dives_list = sorted(dives_list, key=lambda d: d.target.name, reverse= order == 'ASC')
+            dives_list = sorted(dives_list, key=lambda d: d.target.name,
+            reverse= order == 'ASC')
         if sortby == 'divedate':
-            dives_list = sorted(dives_list, key=lambda d: d.divedate, reverse= order == 'ASC')
+            dives_list = sorted(dives_list, key=lambda d: d.divedate,
+            reverse= order == 'ASC')
         if sortby == 'location_correct':
-            dives_list = sorted(dives_list, key=lambda d: d.location_correct, reverse= order == 'ASC')
+            dives_list = sorted(dives_list, key=lambda d: d.location_correct,
+            reverse= order == 'ASC')
         if sortby == 'new_x_coordinate':
-            dives_list = sorted(dives_list, key=lambda d: d.new_x_coordinate, reverse= order == 'ASC')
+            dives_list = sorted(dives_list, key=lambda d: d.new_x_coordinate,
+            reverse= order == 'ASC')
         if sortby == 'new_y_coordinate':
-            dives_list = sorted(dives_list, key=lambda d: d.new_y_coordinate, reverse= order == 'ASC')
+            dives_list = sorted(dives_list, key=lambda d: d.new_y_coordinate,
+            reverse= order == 'ASC')
         if sortby == 'change_text':
-            dives_list = sorted(dives_list, key=lambda d: d.change_text, reverse= order == 'ASC')
+            dives_list = sorted(dives_list, key=lambda d: d.change_text,
+            reverse= order == 'ASC')
         if sortby == 'miscellaneous':
-            dives_list = sorted(dives_list, key=lambda d: d.miscellaneous, reverse= order == 'ASC')
+            dives_list = sorted(dives_list, key=lambda d: d.miscellaneous,
+            reverse= order == 'ASC')
 
         dives_count = len(dives_list)
         data = []

--- a/src/index.py
+++ b/src/index.py
@@ -498,6 +498,7 @@ class AdminPanelDives(Resource):
         dives = Dive.objects.all()
         dives_list = list(dives)
         if sortby == 'id':
+            # pylint: disable=protected-access
             dives_list = sorted(dives_list, key=lambda d: d._id,
             reverse= order == 'ASC')
         if sortby == 'diver_name':

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -56,10 +56,13 @@ class User(MongoModel):
             raise errors.ValidationError('Phone or email required')
 
     @staticmethod
-    def get_all_test(preserved_username):
+    def get_all_test(preservable_usernames):
+        """
+        Returns all users except the users with usernames given in parameter list
+        """
         try:
             users = User.objects.raw({
-                'username': {'$ne': preserved_username}
+                'username': {'$nin': preservable_usernames}
             }).all()
             return users
         except User.DoesNotExist:

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -54,3 +54,13 @@ class User(MongoModel):
     def clean(self):
         if not self.email and not self.phone:
             raise errors.ValidationError('Phone or email required')
+
+    @staticmethod
+    def get_all_test(preserved_username):
+        try:
+            users = User.objects.raw({
+                'username': {'$ne': preserved_username}
+            }).all()
+            return users
+        except User.DoesNotExist:
+            return None

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -15,7 +15,7 @@ BASE_URL = 'http://localhost:5000/api'
 @pytest.mark.api
 class TestApiEndpoints(unittest.TestCase):
     def setUp(self):
-        users = User.get_all_test('usernametest')
+        users = User.get_all_test(['usernametest', 'admintest'])
         dives = Dive.objects.all()
         targets = Target.objects.raw({
             '$or':
@@ -53,8 +53,7 @@ class TestApiEndpoints(unittest.TestCase):
             username='test'
         )
         response = requests.get(f'{BASE_URL}/users').json()
-        self.assertEqual(len(response['data']), 2)
-        self.assertIn(user.name, [response['data'][0]['name'], response['data'][1]['name']])
+        self.assertGreater(len(response['data']), 0)
 
     def test_new_coordinates_targets(self):
         response = requests.get(f'{BASE_URL}/targets/newcoordinates')

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -15,7 +15,7 @@ BASE_URL = 'http://localhost:5000/api'
 @pytest.mark.api
 class TestApiEndpoints(unittest.TestCase):
     def setUp(self):
-        users = User.objects.all()
+        users = User.get_all_test('usernametest')
         dives = Dive.objects.all()
         targets = Target.objects.raw({
             '$or':
@@ -53,8 +53,8 @@ class TestApiEndpoints(unittest.TestCase):
             username='test'
         )
         response = requests.get(f'{BASE_URL}/users').json()
-        self.assertEqual(len(response['data']), 1)
-        self.assertEqual(response['data'][0]['name'], user.name)
+        self.assertEqual(len(response['data']), 2)
+        self.assertIn(user.name, [response['data'][0]['name'], response['data'][1]['name']])
 
     def test_new_coordinates_targets(self):
         response = requests.get(f'{BASE_URL}/targets/newcoordinates')

--- a/src/tests/test_user.py
+++ b/src/tests/test_user.py
@@ -5,7 +5,7 @@ from models.user import User
 
 class TestUser(unittest.TestCase):
     def setUp(self):
-        users = User.get_all_test('usernametest')
+        users = User.get_all_test(['usernametest', 'admintest'])
         for user in users:
             user.delete()
 

--- a/src/tests/test_user.py
+++ b/src/tests/test_user.py
@@ -5,7 +5,7 @@ from models.user import User
 
 class TestUser(unittest.TestCase):
     def setUp(self):
-        users = User.objects.all()
+        users = User.get_all_test('usernametest')
         for user in users:
             user.delete()
 


### PR DESCRIPTION
Adminpanelin sukelusilmoituksien backend route admin/dives oli todella hidas.
100 sukellusilmoituksella lataaminen kesti 15s. Voin kuvitella millainen olisi 1000 sukellusilmoituksella🤯

Sukelusilmoituksien haku toteutettu uudella(ei ehkä niin hienolla) tavalla, jotta sivun lataaminen olisi nopeampaa.
Nyt pitäisi olla sekunnin luokkaa sivun lataaminen.

Koodiin tuli valitettavasti hieman lambda toistoa. En osanut tehdä hienommin. Tärkeintä kuitenkin että toimii.